### PR TITLE
Run deno lint

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,7 +30,7 @@ jobs:
           pnpm build
           pnpm pack
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: packed-tgz
           path: ./binning-*.tgz
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: packed-tgz
 
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: denoland/setup-deno@v2
 
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: packed-tgz
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,6 +15,8 @@ jobs:
 
       - uses: actions/setup-node@v6
 
+      - uses: denoland/setup-deno@v2
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -23,6 +25,7 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm format:check
           pnpm lint
+          deno lint
           pnpm test
           pnpm build
           pnpm pack

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@
  */
 
 import fs from "node:fs";
+import process from "node:process";
 import { buffer } from "node:stream/consumers";
 
 import { ArgumentParser } from "argparse";


### PR DESCRIPTION
This pull request updates the CI workflow and makes a minor improvement to the CLI code. The main focus is on keeping dependencies up-to-date and ensuring both Node.js and Deno environments are properly set up and linted during CI.

**CI workflow improvements:**

* Added `denoland/setup-deno@v2` to the CI workflow to ensure Deno is available for linting and other tasks.
* Added `deno lint` to the CI steps so that Deno code is checked for style and errors.
* Updated `actions/upload-artifact` from v6 to v7 for packing artifacts, and `actions/download-artifact` from v7 to v8 for downloading artifacts, ensuring the workflow uses the latest versions. [[1]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2R28-R33) [[2]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L49-R52) [[3]](diffhunk://#diff-b268bb7dc66e8638921e223098a11eabb92b424875ec72a19d6145dc1efbe3f2L68-R71)

**Codebase maintenance:**

* Added an explicit import of `process` from `node:process` in `src/cli.ts` for improved clarity and compatibility.